### PR TITLE
Switch to console.time for perf measurements

### DIFF
--- a/src/js/shared/util/stopwatch.js
+++ b/src/js/shared/util/stopwatch.js
@@ -1,15 +1,17 @@
-function Stopwatch() {
+function Stopwatch(str) {
   this.startTime = Date.now();
-  this.lastTime = this.startTime;
+  this.lastStart = str;
+  console.time(str);
 }
 
 Stopwatch.prototype.time = function (str) {
-  var newTime = Date.now();
-  console.log(str, 'took ' + (newTime - this.lastTime) + 'ms');
-  this.lastTime = newTime;
+  console.timeEnd(this.lastStart);
+  this.lastStart = str;
+  this.lastTime = Date.now();
 };
 
 Stopwatch.prototype.totalTime = function (str) {
+  console.timeEnd(this.lastStart);
   console.log(str, 'took ' + (Date.now() - this.startTime) + 'ms');
 };
 

--- a/src/js/worker/databaseService.js
+++ b/src/js/worker/databaseService.js
@@ -154,7 +154,7 @@ module.exports = {
     initDBs(couchHome);
   },
   getFullMonsterDataById: async nationalId => {
-    var stopwatch = new Stopwatch();
+    var stopwatch = new Stopwatch('get() monster and monster data');
     var monsterSummary = inMemoryDB.findByNationalId(nationalId);
     var monsterDocId = getDocId(monsterSummary);
     var descDocId = getGeneration5DescriptionDocId(monsterSummary);
@@ -169,7 +169,7 @@ module.exports = {
     var results = await* promises;
     var [monster, description, evolutions, supplemental, types] = results;
 
-    stopwatch.time('get() monster and monster data');
+    stopwatch.totalTime('get() monster and monster data');
     return {monster, description, evolutions, supplemental, types};
   },
   getFilteredMonsters: async (filter) => {

--- a/src/js/worker/index.js
+++ b/src/js/worker/index.js
@@ -21,13 +21,13 @@ var patchMovesList = require('./patchMovesList');
 
 async function renderList() {
   var {filter, start, end} = pageStateStore;
-  var stopwatch = new Stopwatch();
+  var stopwatch = new Stopwatch('patchMonstersList');
   var {patch, endOfList} = await patchMonstersList(filter, start, end);
-  stopwatch.time('patchMonstersList');
-  var patchJson = serialize(patch);
   stopwatch.time('serialize');
-  var patchJsonAsString = JSON.stringify(patchJson);
+  var patchJson = serialize(patch);
   stopwatch.time('JSON.stringify()');
+  var patchJsonAsString = JSON.stringify(patchJson);
+  stopwatch.time('worker-filter (total)');
   console.log('patchJsonAsString.length', patchJsonAsString.length);
 
   self.postMessage({
@@ -35,7 +35,7 @@ async function renderList() {
     patch: patchJsonAsString,
     endOfList: endOfList
   });
-  stopwatch.totalTime('worker-filter (total)');
+  stopwatch.totalTime();
 }
 
 async function onFilterMessage(message) {
@@ -63,22 +63,22 @@ function setThemeColor(nationalId) {
 
 async function onDetailMessage(message) {
   var {nationalId} = message;
-  var stopwatch = new Stopwatch();
+  var stopwatch = new Stopwatch('patchMonsterDetail()');
   var patchPromise = patchMonsterDetail(nationalId);
   setThemeColor(nationalId);
   var {patch} = await patchPromise;
-  stopwatch.time('patchMonsterDetail()');
-  var patchJson = serialize(patch);
   stopwatch.time('serialize');
-  var patchJsonAsString = JSON.stringify(patchJson);
+  var patchJson = serialize(patch);
   stopwatch.time('JSON.stringify()');
+  var patchJsonAsString = JSON.stringify(patchJson);
+  stopwatch.time('worker-detail (total)');
   console.log('patchJsonAsString.length', patchJsonAsString.length);
   self.postMessage({
     type: 'monsterDetailPatch',
     patch: patchJsonAsString,
     nationalId: nationalId
   });
-  stopwatch.totalTime('worker-detail (total)');
+  stopwatch.totalTime();
 }
 
 async function onMovesDetailMessage(message) {

--- a/src/js/worker/patchMonsterDetail.js
+++ b/src/js/worker/patchMonsterDetail.js
@@ -10,19 +10,19 @@ var fromJson = require('vdom-as-json/fromJson');
 var lastDetailView = fromJson(require('../shared/prerendered/bulbasaur'));
 
 module.exports = async nationalId => {
-  var stopwatch = new Stopwatch();
+  var stopwatch = new Stopwatch('detail: fetching monsterData');
   var fullMonsterData = await dbService.getFullMonsterDataById(nationalId);
-  stopwatch.time('detail: fetching monsterData');
+  stopwatch.time('detail: rendering');
 
   var newDetailView = renderDetailView(fullMonsterData);
 
-  stopwatch.time('detail: rendering');
+  stopwatch.time('detail: diffing');
 
   var patch = diff(lastDetailView, newDetailView);
 
   lastDetailView = newDetailView;
 
-  stopwatch.time('detail: diffing');
+  stopwatch.time();
 
   return {patch};
 };

--- a/src/js/worker/patchMonstersList.js
+++ b/src/js/worker/patchMonstersList.js
@@ -10,7 +10,7 @@ var fromJson = require('vdom-as-json/fromJson');
 var lastMonstersListView = fromJson(require('../shared/prerendered/monsterSummaries.json'));
 
 module.exports = async (filter, pageSize, start, end) => {
-  var stopwatch = new Stopwatch();
+  var stopwatch = new Stopwatch('getting monsters');
 
   var newMonsters;
   if (filter) {
@@ -19,14 +19,14 @@ module.exports = async (filter, pageSize, start, end) => {
     newMonsters = await dbService.getAllMonsters();
   }
 
-  stopwatch.time('getting monsters');
-  var newMonstersList = renderMonstersList(newMonsters, pageSize, start, end);
   stopwatch.time('rendering monsters');
+  var newMonstersList = renderMonstersList(newMonsters, pageSize, start, end);
+  stopwatch.time('diffing monsters');
 
   var patch = diff(lastMonstersListView, newMonstersList);
   var endOfList = newMonsters.length <= pageSize;
   console.log('newMonsters.length', newMonsters.length, 'pageSize', pageSize);
-  stopwatch.time('diffing monsters');
+  stopwatch.time();
   lastMonstersListView = newMonstersList;
 
   return {patch, endOfList};

--- a/src/js/worker/patchMovesList.js
+++ b/src/js/worker/patchMovesList.js
@@ -7,14 +7,14 @@ var Stopwatch = require('../shared/util/stopwatch');
 var lastMovesList = h('div.monster-moves');
 
 module.exports = async nationalId => {
-  var stopwatch = new Stopwatch();
+  var stopwatch = new Stopwatch('Fetching monster moves');
   var monsterSummary = databaseService.getMonsterSummaryById(nationalId);
   var moves = await databaseService.getMonsterMovesById(nationalId);
-  stopwatch.time('Fetching monster moves');
+  stopwatch.time('Patching monster moves');
   var newMovesList = renderMovesList(monsterSummary, moves);
 
   var patch = diff(lastMovesList, newMovesList);
-  stopwatch.time('Patching monster moves');
+  stopwatch.time();
   lastMovesList = newMovesList;
 
   return {patch};


### PR DESCRIPTION
Fixes #13 

By using this new way, not only do we get the same logs in the console, but we also get awesome timeline markers :tada: 

![screen shot 2015-11-25 at 12 31 48 pm](https://cloud.githubusercontent.com/assets/883126/11408894/e8b74cb4-9370-11e5-9f0f-67f4ddd9b141.png)

![screen shot 2015-11-25 at 12 40 27 pm](https://cloud.githubusercontent.com/assets/883126/11408992/c74fe9e0-9371-11e5-8b7b-e978ecc5a66d.png)
![screen shot 2015-11-25 at 12 40 17 pm](https://cloud.githubusercontent.com/assets/883126/11408993/c761f036-9371-11e5-8786-d6ef3fee6720.png)

Awesome job on this PS :clap: 