### PR TITLE
Fix for lazy load

### DIFF
--- a/src/js/client/main/scrollingList.js
+++ b/src/js/client/main/scrollingList.js
@@ -71,7 +71,7 @@ function binarySearchForFirstInvisibleChild(start, children) {
   return low;
 }
 
-function onScroll() {
+function onViewportChange() {
   if (!monstersList) {
     return;
   }
@@ -125,8 +125,8 @@ document.addEventListener('DOMContentLoaded', () => {
       showMonsterDetail(nationalId);
     }
   });
-  onScroll();
+  onViewportChange();
 }, false);
 
-window.addEventListener('scroll', progressiveDebounce(onScroll, DEBOUNCE_DELAY));
-window.addEventListener('resize', debounce(onScroll, 50));
+window.addEventListener('scroll', progressiveDebounce(onViewportChange, DEBOUNCE_DELAY));
+window.addEventListener('resize', debounce(onViewportChange, 50));

--- a/src/js/client/main/scrollingList.js
+++ b/src/js/client/main/scrollingList.js
@@ -130,3 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 window.addEventListener('scroll', progressiveDebounce(onViewportChange, DEBOUNCE_DELAY));
 window.addEventListener('resize', debounce(onViewportChange, 50));
+
+module.exports = {
+  onViewportChange: onViewportChange
+};

--- a/src/js/client/main/sideMenu.js
+++ b/src/js/client/main/sideMenu.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   var $ = document.querySelector.bind(document);
   var sideDrawer = $('#sidedrawer');
+  var scrollingList = require('./scrollingList');
 
   function showSidedrawer() {
     // show overlay
@@ -24,6 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
       sideDrawer.classList.remove('active');
       setTimeout(() => {
         document.body.classList.toggle('hide-sidedrawer');
+        scrollingList.onViewportChange();
+        
         if ($('#mui-overlay')) {
           mui.overlay('off');
         }


### PR DESCRIPTION
Ref #18 

This is untested, couldn't get the dev environment up and running and I away for the weekend, so pushed this up in case someone else can confirm or take this to a complete PR.

I was in-between manually firing a ```resize``` or ```scroll``` event but I think manually calling the function is much clearer.

Also renamed onScroll to onViewportChange to describe the function better, however I still think onViewportChange isn't quite right.