### PR TITLE
High performance animations switch (fixes #36)

### DIFF
--- a/src/js/client/main/utils.js
+++ b/src/js/client/main/utils.js
@@ -9,6 +9,12 @@ module.exports = {
     return !isSafari;
   },
   canRunHighPerfAnims: () => {
+    // force setting via highPerfAnims query parameter (0/1)
+    var force = window.location.search.match(/highPerfAnims=(\d)/);
+    if (force) {
+      return (force[1] == 1);
+    }
+
     // it is a pretty safe assumption that android 4 devices are not
     // running on great hardware. this is an inexact metric, but it
     // ought to be pretty safe for the time being


### PR DESCRIPTION
Switch to force `canRunHighPerfAnims()` setting via a query parameter.
Fixes #36, and would help a lot to debug #35.