### PR TITLE
[ISSUE4] fixes smooth scrolling in detail view on iphone

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -403,7 +403,8 @@ button {
   top: 0;
   left: 10px;
   right: 10px;
-  overflow-y: auto;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .detail-panel.animating {

--- a/src/js/client/main/detailViewOrchestrator.js
+++ b/src/js/client/main/detailViewOrchestrator.js
@@ -165,7 +165,7 @@ function doInAnimationPartOne(nationalId) {
 function doInAnimationPartTwo(nationalId) {
   spinnerHolder.classList.remove('shown');
   clearTimeout(spinnerTimeout);
-  detailPanel.style.overflowY = 'auto'; // re-enable overflow on the panel
+  detailPanel.style.overflowY = 'scroll'; // re-enable overflow on the panel
   document.body.style.overflowY = 'hidden'; // disable scrolling
 
   // hide monster moves until they're shown after the panel


### PR DESCRIPTION
Fixes #4 adding `-webkit-overflow-scrolling: touch;` to smooth scroll the detail view on iphones. 

note\* overflow-y: must be set to `overflow-y: scroll` to get this to work.
