### PR TITLE
Remove a duplicate `require` line

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -3,7 +3,6 @@ var childProcess = require('child_process');
 var bluebird = require('bluebird');
 var mkdirp = bluebird.promisify(require('mkdirp'));
 var fs = bluebird.promisifyAll(require('fs'));
-var build = require('./build');
 var PouchDB = require('pouchdb-core')
   .plugin(require('pouchdb-adapter-http'))
   .plugin(require('pouchdb-adapter-leveldb'))


### PR DESCRIPTION
The `./build` module has been required twice in `bin/dev-server.js`.