### PR TITLE
add search label for screen readers only

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1039,3 +1039,12 @@ button.dropdown-button:hover {
   background-color: #fafafa;
 }
 
+/* screen reader only */
+.sr-only {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -56,10 +56,10 @@
 
     <h1 id="main-title">Pokedex.org</h1>
 
-    <div class="mui-textfield mui-textfield--float-label">
-      <input id="monsters-search-bar" type="search"
+    <div class="mui-textfield">
+      <input id="monsters-search-bar" type="search" placeholder="Search for Pokémon"
              spellcheck="false" autocorrect="off" autocomplete="off"/>
-      <label for="monsters-search-bar">Search for Pokémon</label>
+      <label for="monsters-search-bar" class="sr-only">Search for Pokémon</label>
     </div>
     
 


### PR DESCRIPTION
Per discussion in https://github.com/nolanlawson/pokedex.org/pull/64#issuecomment-257191919, I'd rather have screen reader support while also avoiding janky animations. The default MUI animation for label text looks great on desktop but on mobile it's very low-framerate. This PR puts a label offscreen that only a screen reader can see, using the `sr-only` class convention from Bootstrap.